### PR TITLE
Fix to signing logic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 language: scala
 scala:
   - 2.10.6

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,0 +1,3 @@
+resolvers += "maven repo" at "https://repo1.maven.org/maven2/"
+
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.5")

--- a/src/main/scala/com/github/_3tty0n/jwt/JWT.scala
+++ b/src/main/scala/com/github/_3tty0n/jwt/JWT.scala
@@ -5,7 +5,7 @@ import play.api.libs.json._
 import javax.crypto.spec.SecretKeySpec
 import org.apache.commons.codec.binary.Base64
 
-import scala.util.{Failure, Success, Try}
+import scala.util.{Try, Success, Failure}
 
 
 object JWT {

--- a/src/main/scala/com/github/_3tty0n/jwt/JWT.scala
+++ b/src/main/scala/com/github/_3tty0n/jwt/JWT.scala
@@ -84,7 +84,7 @@ object JWT {
 
 
   /**
-   * encode first part on jwt 'header'
+   * encode first part on jwt 'header', fixing alpha order on fields
    * @param algorithm that represent algorithm using on JWT
    * @param header that represent data for JWT header
    * @return String
@@ -92,9 +92,9 @@ object JWT {
   private[jwt] def encodeHeader(algorithm: Option[Algorithm], header: JsObject): String = {
     val h = algorithm match {
       case Some(alg) => Json.obj("alg" -> alg.name, "typ" -> "JWT") ++ header
-      case None => Json.obj("typ" -> "JWT", "alg" -> "") ++ header
+      case None => Json.obj("alg" -> "","typ" -> "JWT") ++ header
     }
-    encodeBase64url(Json.stringify(h))
+    encodeBase64url(Json.stringify(JsObject(h.fields.sortBy(_._1))))
   }
 
   /**

--- a/src/main/scala/com/github/_3tty0n/jwt/JWT.scala
+++ b/src/main/scala/com/github/_3tty0n/jwt/JWT.scala
@@ -1,12 +1,11 @@
 package com.github._3tty0n.jwt
 
 import javax.crypto.Mac
-import JWTException.InvalidAlgorithm
 import play.api.libs.json._
 import javax.crypto.spec.SecretKeySpec
 import org.apache.commons.codec.binary.Base64
 
-import scala.util.{Try, Success, Failure}
+import scala.util.{Failure, Success, Try}
 
 
 object JWT {
@@ -37,7 +36,7 @@ object JWT {
   private[jwt] def signHmac(algorithm: Algorithm, msg: String, key: String): String = {
     val mac: Mac = Mac.getInstance(algorithm.toString)
     mac.init(new SecretKeySpec(key.getBytes("utf-8"), algorithm.toString))
-    encodeBase64url(new String(mac.doFinal(msg.getBytes("utf-8"))))
+    Base64.encodeBase64URLSafeString(mac.doFinal(msg.getBytes("utf-8")))
   }
 
   /**


### PR DESCRIPTION
@3tty0n 

Please note that the ordering of operations in signHmac() is critical as the generation of a string from the signed output of mac.doFinal() changes the byte length and thus produces a dramatically different resulting JWT.

This result is consistent with the other project dealing with JWT:

https://github.com/jasongoodwin/authentikat-jwt/blob/master/src/main/scala/authentikat/jwt/JsonWebSignature.scala#L43-L49

A quick walk through the debugger will expose this.

I've also added the plug-in for the build which was missing.